### PR TITLE
Adapters without deserialization

### DIFF
--- a/src/Eshopworld.Messaging/AssemblyInfo.cs
+++ b/src/Eshopworld.Messaging/AssemblyInfo.cs
@@ -2,3 +2,4 @@
 
 [assembly: InternalsVisibleTo("Eshopworld.Messaging.Tests")]
 [assembly: InternalsVisibleTo("Eshopworld.Messaging.Tests.Profiler")]
+[assembly: InternalsVisibleTo("CaptainHook.EventReaderActor")]

--- a/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
+++ b/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     
-    <Version>1.0.0</Version>
-    <PackageReleaseNotes>Initial add after package rebranding.</PackageReleaseNotes>
+    <Version>1.0.1</Version>
+    <PackageReleaseNotes>Added an internal optional route to bypass event deserialization during subscribe.</PackageReleaseNotes>
 
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>

--- a/src/Eshopworld.Messaging/QueueAdapter.cs
+++ b/src/Eshopworld.Messaging/QueueAdapter.cs
@@ -28,7 +28,7 @@
         /// <param name="messagesIn">The <see cref="IObserver{IMessage}"/> used to push received messages into the pipeline.</param>
         /// <param name="batchSize">The size of the batch when reading for a queue - used as the pre-fetch parameter of the </param>
         public QueueAdapter([NotNull]string connectionString, [NotNull]string subscriptionId, [NotNull]IObserver<T> messagesIn, int batchSize)
-            : base(connectionString, subscriptionId, messagesIn, batchSize)
+            : base(connectionString, subscriptionId, messagesIn, batchSize, typeOverride: null)
         {
             AzureQueue = AzureServiceBusNamespace.CreateQueueIfNotExists(typeof(T).GetEntityName()).Result;
 

--- a/src/Eshopworld.Messaging/ServiceBusAdapter.cs
+++ b/src/Eshopworld.Messaging/ServiceBusAdapter.cs
@@ -1,5 +1,13 @@
 ﻿namespace Eshopworld.Messaging
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
+    using System.Text;
+    using System.Text.RegularExpressions;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Core;
     using JetBrains.Annotations;
     using Microsoft.Azure.Management.Fluent;
@@ -12,14 +20,6 @@
     using Microsoft.Azure.Services.AppAuthentication;
     using Microsoft.Rest;
     using Newtonsoft.Json;
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Linq;
-    using System.Text;
-    using System.Text.RegularExpressions;
-    using System.Threading;
-    using System.Threading.Tasks;
 
     internal abstract class ServiceBusAdapter<T> : ServiceBusAdapter
         where T : class

--- a/src/Eshopworld.Messaging/TopicAdapter.cs
+++ b/src/Eshopworld.Messaging/TopicAdapter.cs
@@ -28,9 +28,16 @@
         /// <param name="subscriptionId">The ID of the subscription where the service bus namespace lives.</param>
         /// <param name="messagesIn">The <see cref="IObserver{IMessage}"/> used to push received messages into the pipeline.</param>
         /// <param name="batchSize">The size of the batch when reading for a queue - used as the pre-fetch parameter of the </param>
-        public TopicAdapter([NotNull]string connectionString, [NotNull]string subscriptionId, [NotNull]IObserver<T> messagesIn, int batchSize)
-            : base(connectionString, subscriptionId, messagesIn, batchSize)
+        /// <param name="typeOverride">The type override when we're creating a topic adapter for <see cref="string"/> types.</param>
+        public TopicAdapter([NotNull]string connectionString, [NotNull]string subscriptionId, [NotNull]IObserver<T> messagesIn, int batchSize, Type typeOverride = null)
+            : base(connectionString, subscriptionId, messagesIn, batchSize, typeOverride)
         {
+            if (typeof(T) == typeof(string) && typeOverride == null)
+                throw new InvalidOperationException("You can't create a TopicAdapter of type string without specifying a typeOverride");
+
+            if(typeof(T) != typeof(string) && typeOverride != null)
+                throw new InvalidOperationException($"typeOverride is only respected if you're creating a TopicAdapter where T:string, and this one is for {typeof(T).FullName}");
+
             AzureTopic = AzureServiceBusNamespace.CreateTopicIfNotExists(typeof(T).GetEntityName()).Result;
             Sender = new TopicClient(connectionString, AzureTopic.Name, new RetryExponential(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(500), 3));
         }

--- a/src/Eshopworld.Messaging/TopicAdapter.cs
+++ b/src/Eshopworld.Messaging/TopicAdapter.cs
@@ -32,13 +32,14 @@
         public TopicAdapter([NotNull]string connectionString, [NotNull]string subscriptionId, [NotNull]IObserver<T> messagesIn, int batchSize, Type typeOverride = null)
             : base(connectionString, subscriptionId, messagesIn, batchSize, typeOverride)
         {
-            if (typeof(T) == typeof(string) && typeOverride == null)
-                throw new InvalidOperationException("You can't create a TopicAdapter of type string without specifying a typeOverride");
+            if (typeof(T) == typeof(Message) && typeOverride == null)
+                throw new InvalidOperationException($"You can't create a TopicAdapter of type {typeof(Message).FullName} without specifying a typeOverride");
 
-            if(typeof(T) != typeof(string) && typeOverride != null)
-                throw new InvalidOperationException($"typeOverride is only respected if you're creating a TopicAdapter where T:string, and this one is for {typeof(T).FullName}");
+            if(typeof(T) != typeof(Message) && typeOverride != null)
+                throw new InvalidOperationException($"typeOverride is only respected if you're creating a TopicAdapter where T:{typeof(Message).FullName}, and this one is for {typeof(T).FullName}");
 
-            AzureTopic = AzureServiceBusNamespace.CreateTopicIfNotExists(typeof(T).GetEntityName()).Result;
+            var topicType = typeOverride ?? typeof(T);
+            AzureTopic = AzureServiceBusNamespace.CreateTopicIfNotExists(topicType.GetEntityName()).Result;
             Sender = new TopicClient(connectionString, AzureTopic.Name, new RetryExponential(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(500), 3));
         }
 


### PR DESCRIPTION
This is a bypass mechanism for `CaptainHook` to be able to tap directly in the SDK Message type without de-serialization and the `Dictionary` pressure to reference the SDK Message from any POCO.

Essentially it allows this:
```c#
var adapter = new TopicAdapter<Message>(ServiceBusFixture.ConfigSettings.ConnectionString, ServiceBusFixture.ConfigSettings.SubscriptionId, messagesSubject, 10, typeof(TestMessage));
```