### PR TITLE
Bug/fix topic naming

### DIFF
--- a/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
+++ b/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageReleaseNotes>Added an internal optional route to bypass event deserialization during subscribe.</PackageReleaseNotes>
 
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/Eshopworld.Messaging/QueueAdapter.cs
+++ b/src/Eshopworld.Messaging/QueueAdapter.cs
@@ -62,7 +62,7 @@
             var qMessage = new Message(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message)))
             {
                 ContentType = "application/json",
-                Label = message.GetType().FullName
+                Label = message.GetType().Name
             };
 
             await Sender.SendAsync(qMessage).ConfigureAwait(false);

--- a/src/Eshopworld.Messaging/ServiceBusFluentExtensions.cs
+++ b/src/Eshopworld.Messaging/ServiceBusFluentExtensions.cs
@@ -99,7 +99,7 @@
         public static string GetEntityName(this Type type)
         {
 #if DEBUG
-            var queueName = type.FullName;
+            var queueName = type.Name;
             if (Debugger.IsAttached)
             {
                 queueName += $"-{Environment.UserName.Replace("$", "")}";
@@ -107,7 +107,7 @@
 
             return queueName?.ToLower();
 #else
-            return type.FullName?.ToLower();
+            return type.Name?.ToLower();
 #endif
         }
     }

--- a/src/Eshopworld.Messaging/TopicAdapter.cs
+++ b/src/Eshopworld.Messaging/TopicAdapter.cs
@@ -82,7 +82,7 @@
             var qMessage = new Message(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message)))
             {
                 ContentType = "application/json",
-                Label = message.GetType().FullName
+                Label = message.GetType().Name
             };
 
             await Sender.SendAsync(qMessage).ConfigureAwait(false);

--- a/src/Eshopworld.Messaging/TopicAdapter.cs
+++ b/src/Eshopworld.Messaging/TopicAdapter.cs
@@ -39,7 +39,7 @@
                 throw new InvalidOperationException($"typeOverride is only respected if you're creating a TopicAdapter where T:{typeof(Message).FullName}, and this one is for {typeof(T).FullName}");
 
             var topicType = typeOverride ?? typeof(T);
-            AzureTopic = AzureServiceBusNamespace.CreateTopicIfNotExists(topicType.Name).Result;
+            AzureTopic = AzureServiceBusNamespace.CreateTopicIfNotExists(topicType.GetEntityName()).Result;
             Sender = new TopicClient(connectionString, AzureTopic.Name, new RetryExponential(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(500), 3));
         }
 

--- a/src/Eshopworld.Messaging/TopicAdapter.cs
+++ b/src/Eshopworld.Messaging/TopicAdapter.cs
@@ -39,7 +39,7 @@
                 throw new InvalidOperationException($"typeOverride is only respected if you're creating a TopicAdapter where T:{typeof(Message).FullName}, and this one is for {typeof(T).FullName}");
 
             var topicType = typeOverride ?? typeof(T);
-            AzureTopic = AzureServiceBusNamespace.CreateTopicIfNotExists(topicType.GetEntityName()).Result;
+            AzureTopic = AzureServiceBusNamespace.CreateTopicIfNotExists(topicType.Name).Result;
             Sender = new TopicClient(connectionString, AzureTopic.Name, new RetryExponential(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(500), 3));
         }
 

--- a/src/Tests/Eshopworld.Messaging.Tests/ChildTestMessage.cs
+++ b/src/Tests/Eshopworld.Messaging.Tests/ChildTestMessage.cs
@@ -1,0 +1,4 @@
+﻿public class ChildTestMessage : TestMessage
+{
+
+}

--- a/src/Tests/Eshopworld.Messaging.Tests/MessengerTopicTest.cs
+++ b/src/Tests/Eshopworld.Messaging.Tests/MessengerTopicTest.cs
@@ -28,6 +28,18 @@ public class MessengerTopicTest
     }
 
     [Fact, IsIntegration]
+    public async Task Test_SendCreatesTheTopicAsChildEntityName()
+    {
+        await ServiceBusFixture.ServiceBusNamespace.ScorchNamespace();
+
+        using (IDoFullMessaging msn = new Messenger(ServiceBusFixture.ConfigSettings.ConnectionString, ServiceBusFixture.ConfigSettings.SubscriptionId))
+        {
+            await msn.Publish(new PlatformOrderCreateDomainEvent());
+            ServiceBusFixture.ServiceBusNamespace.AssertSingleTopicExists(typeof(PlatformOrderCreateDomainEvent));
+        }
+    }
+
+    [Fact, IsIntegration]
     public async Task Test_SendCreatesTheTopic()
     {
         await ServiceBusFixture.ServiceBusNamespace.ScorchNamespace();

--- a/src/Tests/Eshopworld.Messaging.Tests/MessengerTopicTest.cs
+++ b/src/Tests/Eshopworld.Messaging.Tests/MessengerTopicTest.cs
@@ -34,8 +34,8 @@ public class MessengerTopicTest
 
         using (IDoFullMessaging msn = new Messenger(ServiceBusFixture.ConfigSettings.ConnectionString, ServiceBusFixture.ConfigSettings.SubscriptionId))
         {
-            await msn.Publish(new PlatformOrderCreateDomainEvent());
-            ServiceBusFixture.ServiceBusNamespace.AssertSingleTopicExists(typeof(PlatformOrderCreateDomainEvent));
+            await msn.Publish(new ChildTestMessage());
+            ServiceBusFixture.ServiceBusNamespace.AssertSingleTopicExists(typeof(ChildTestMessage));
         }
     }
 


### PR DESCRIPTION
Slight change to the Domain event names such that the namespace is not used in the topic/queue name.

Associated with https://github.com/eShopWorld/telemetry/pull/11