### PR TITLE
Bug/azureservicebus caching

### DIFF
--- a/src/Eshopworld.Messaging/DictionaryExtensions.cs
+++ b/src/Eshopworld.Messaging/DictionaryExtensions.cs
@@ -1,8 +1,8 @@
-﻿namespace Eshopworld.Messaging
-{
-    using System;
-    using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
+namespace Eshopworld.Messaging
+{
     /// <summary>
     /// Contains extensions to <see cref="System.Collections.IDictionary"/>.
     /// </summary>

--- a/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
+++ b/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     
-    <Version>1.0.1</Version>
-    <PackageReleaseNotes>Added an internal optional route to bypass event deserialization during subscribe.</PackageReleaseNotes>
+    <Version>1.0.2</Version>
+    <PackageReleaseNotes>Fixed a bug where we were caching fluent objects that would expire the token in certain scenarios.</PackageReleaseNotes>
 
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>

--- a/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
+++ b/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
@@ -24,12 +24,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="eshopworld.core" Version="2.0.0" />
-    <PackageReference Include="jetbrains.annotations" Version="2018.2.1" />
-    <PackageReference Include="microsoft.azure.management.fluent" Version="1.15.1" />
-    <PackageReference Include="microsoft.azure.servicebus" Version="3.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="system.reactive" Version="4.1.0" />
+    <PackageReference Include="eshopworld.core" Version="2.1.1" />
+    <PackageReference Include="jetbrains.annotations" Version="2019.1.1" />
+    <PackageReference Include="microsoft.azure.management.fluent" Version="1.22.2" />
+    <PackageReference Include="microsoft.azure.servicebus" Version="3.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="system.reactive" Version="4.1.5" />
   </ItemGroup>
 
 </Project>

--- a/src/Eshopworld.Messaging/Messenger.cs
+++ b/src/Eshopworld.Messaging/Messenger.cs
@@ -191,7 +191,6 @@ namespace Eshopworld.Messaging
         internal ServiceBusAdapter<T> SetupMessageType<T>(int batchSize, MessagingTransport transport) where T : class
         {
             ServiceBusAdapter adapter = null;
-            var messageType = typeof(T);
 
             if (!ServiceBusAdapters.ContainsKey(typeof(T)))
             {

--- a/src/Eshopworld.Messaging/ServiceBusExtensions.cs
+++ b/src/Eshopworld.Messaging/ServiceBusExtensions.cs
@@ -1,13 +1,12 @@
-﻿using System.Text.RegularExpressions;
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.Azure.Management.ServiceBus.Fluent;
 
 namespace Eshopworld.Messaging
 {
-    using System;
-    using System.Diagnostics;
-    using System.Linq;
-    using System.Threading.Tasks;
-    using Microsoft.Azure.Management.ServiceBus.Fluent;
-
     /// <summary>
     /// Contains extensions to the ServiceBus Fluent SDK: <see cref="Microsoft.Azure.Management.ServiceBus.Fluent"/>.
     /// </summary>

--- a/src/Tests/Eshopworld.Messaging.Tests/AzureServiceBusFixture.cs
+++ b/src/Tests/Eshopworld.Messaging.Tests/AzureServiceBusFixture.cs
@@ -42,9 +42,9 @@
                                                        new DefaultKeyVaultSecretManager())
                                                    .Build();
 
-            config.GetSection("Messaging").Bind(ConfigSettings);
+            config.Bind(ConfigSettings);
 
-            var namespaceName = Regex.Match(ConfigSettings.ConnectionString, @"Endpoint=sb:\/\/([^.]*)", RegexOptions.IgnoreCase).Groups[1].Value;
+            var namespaceName = Regex.Match(ConfigSettings.ServiceBusConnectionString, @"Endpoint=sb:\/\/([^.]*)", RegexOptions.IgnoreCase).Groups[1].Value;
 
             var token = tokenProvider.GetAccessTokenAsync("https://management.core.windows.net/", string.Empty).Result;
             var tokenCredentials = new TokenCredentials(token);
@@ -56,13 +56,13 @@
                                    .Build();
 
             ServiceBusNamespace = Azure.Authenticate(client, string.Empty)
-                                       .WithSubscription(ConfigSettings.SubscriptionId)
+                                       .WithSubscription(ConfigSettings.AzureSubscriptionId)
                                        .ServiceBusNamespaces.List()
                                        .SingleOrDefault(n => n.Name == namespaceName);
 
             if (ServiceBusNamespace == null)
             {
-                throw new InvalidOperationException($"Couldn't find the service bus namespace {namespaceName} in the subscription with ID {ConfigSettings.SubscriptionId}");
+                throw new InvalidOperationException($"Couldn't find the service bus namespace {namespaceName} in the subscription with ID {ConfigSettings.AzureSubscriptionId}");
             }
         }
     }
@@ -80,8 +80,8 @@
     /// </summary>
     public class MessagingSettings
     {
-        public string ConnectionString { get; set; }
+        public string ServiceBusConnectionString { get; set; }
 
-        public string SubscriptionId { get; set; }
+        public string AzureSubscriptionId { get; set; }
     }
 }

--- a/src/Tests/Eshopworld.Messaging.Tests/Eshopworld.Messaging.Tests.csproj
+++ b/src/Tests/Eshopworld.Messaging.Tests/Eshopworld.Messaging.Tests.csproj
@@ -10,17 +10,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="eshopworld.core" Version="2.0.0" />
-    <PackageReference Include="eshopworld.tests.core" Version="1.0.4" />
-    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.0" />
-    <PackageReference Include="microsoft.azure.management.fluent" Version="1.15.1" />
-    <PackageReference Include="microsoft.azure.servicebus" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="system.reactive" Version="4.1.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
+    <PackageReference Include="eshopworld.core" Version="2.1.1" />
+    <PackageReference Include="eshopworld.tests.core" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.3" />
+    <PackageReference Include="microsoft.azure.management.fluent" Version="1.22.2" />
+    <PackageReference Include="microsoft.azure.servicebus" Version="3.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="system.reactive" Version="4.1.5" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Tests/Eshopworld.Messaging.Tests/MessengerQueueTest.cs
+++ b/src/Tests/Eshopworld.Messaging.Tests/MessengerQueueTest.cs
@@ -24,7 +24,7 @@ public class MessengerQueueTest
         ServiceBusFixture = serviceBusFixture;
     }
 
-    [Fact, IsIntegration]
+    [Fact, IsLayer1]
     public async Task Test_SendCreatesTheQueue()
     {
         await ServiceBusFixture.ServiceBusNamespace.ScorchNamespace();
@@ -36,7 +36,7 @@ public class MessengerQueueTest
         }
     }
 
-    [Fact, IsIntegration]
+    [Fact, IsLayer1]
     public async Task Test_ReceiveCreatesTheQueue()
     {
         await ServiceBusFixture.ServiceBusNamespace.ScorchNamespace();
@@ -48,7 +48,7 @@ public class MessengerQueueTest
         }
     }
 
-    [Fact, IsIntegration]
+    [Fact, IsLayer1]
     public async Task Test_SendingRandomMessages()
     {
         var sendCount = new Random().Next(1, 10);
@@ -74,7 +74,7 @@ public class MessengerQueueTest
         }
     }
 
-    [Fact, IsIntegration]
+    [Fact, IsLayer1]
     public async Task Test_ReceivingRandomMessages()
     {
         var receiveCount = new Random().Next(1, 10);
@@ -111,7 +111,7 @@ public class MessengerQueueTest
         }
     }
 
-    [Fact, IsIntegration]
+    [Fact, IsLayer1]
     public async Task Test_LockMessage_ForFiveMinutes()
     {
         await ServiceBusFixture.ServiceBusNamespace.ScorchNamespace();
@@ -135,7 +135,7 @@ public class MessengerQueueTest
         }
     }
 
-    [Fact, IsIntegration]
+    [Fact, IsLayer1]
     public async Task Test_LockAbandon_MessageFlow()
     {
         await ServiceBusFixture.ServiceBusNamespace.ScorchNamespace();
@@ -167,7 +167,7 @@ public class MessengerQueueTest
         }
     }
 
-    [Fact, IsIntegration]
+    [Fact, IsLayer1]
     public async Task Test_LockComplete_MessageFlow()
     {
         await ServiceBusFixture.ServiceBusNamespace.ScorchNamespace();
@@ -198,7 +198,7 @@ public class MessengerQueueTest
         }
     }
 
-    [Fact, IsIntegration]
+    [Fact, IsLayer1]
     public async Task Test_LockError_MessageFlow()
     {
         await ServiceBusFixture.ServiceBusNamespace.ScorchNamespace();

--- a/src/Tests/Eshopworld.Messaging.Tests/MessengerQueueTest.cs
+++ b/src/Tests/Eshopworld.Messaging.Tests/MessengerQueueTest.cs
@@ -29,7 +29,7 @@ public class MessengerQueueTest
     {
         await ServiceBusFixture.ServiceBusNamespace.ScorchNamespace();
 
-        using (IDoFullMessaging msn = new Messenger(ServiceBusFixture.ConfigSettings.ConnectionString, ServiceBusFixture.ConfigSettings.SubscriptionId))
+        using (IDoFullMessaging msn = new Messenger(ServiceBusFixture.ConfigSettings.ServiceBusConnectionString, ServiceBusFixture.ConfigSettings.AzureSubscriptionId))
         {
             await msn.Send(new TestMessage());
             ServiceBusFixture.ServiceBusNamespace.AssertSingleQueueExists(typeof(TestMessage));
@@ -41,7 +41,7 @@ public class MessengerQueueTest
     {
         await ServiceBusFixture.ServiceBusNamespace.ScorchNamespace();
 
-        using (IDoFullMessaging msn = new Messenger(ServiceBusFixture.ConfigSettings.ConnectionString, ServiceBusFixture.ConfigSettings.SubscriptionId))
+        using (IDoFullMessaging msn = new Messenger(ServiceBusFixture.ConfigSettings.ServiceBusConnectionString, ServiceBusFixture.ConfigSettings.AzureSubscriptionId))
         {
             msn.Receive<TestMessage>(_ => { });
             ServiceBusFixture.ServiceBusNamespace.AssertSingleQueueExists(typeof(TestMessage));
@@ -58,7 +58,7 @@ public class MessengerQueueTest
         var messages = new List<TestMessage>();
         for (var i = 0; i < sendCount; i++) { messages.Add(new TestMessage()); }
 
-        using (IDoFullMessaging msn = new Messenger(ServiceBusFixture.ConfigSettings.ConnectionString, ServiceBusFixture.ConfigSettings.SubscriptionId))
+        using (IDoFullMessaging msn = new Messenger(ServiceBusFixture.ConfigSettings.ServiceBusConnectionString, ServiceBusFixture.ConfigSettings.AzureSubscriptionId))
         {
             foreach (var message in messages)
             {
@@ -67,7 +67,7 @@ public class MessengerQueueTest
 
             await Task.Delay(TimeSpan.FromSeconds(5)); // wait 5 seconds to flush out all the messages
 
-            var receiver = new MessageReceiver(ServiceBusFixture.ConfigSettings.ConnectionString, typeof(TestMessage).GetEntityName(), ReceiveMode.ReceiveAndDelete, null, sendCount);
+            var receiver = new MessageReceiver(ServiceBusFixture.ConfigSettings.ServiceBusConnectionString, typeof(TestMessage).GetEntityName(), ReceiveMode.ReceiveAndDelete, null, sendCount);
             var rMessages = (await receiver.ReadBatchAsync<TestMessage>(sendCount)).ToList();
 
             rMessages.Should().BeEquivalentTo(messages);
@@ -85,7 +85,7 @@ public class MessengerQueueTest
         for (var i = 0; i < receiveCount; i++) { messages.Add(new TestMessage()); }
 
         using (var ts = new CancellationTokenSource())
-        using (IDoFullMessaging msn = new Messenger(ServiceBusFixture.ConfigSettings.ConnectionString, ServiceBusFixture.ConfigSettings.SubscriptionId))
+        using (IDoFullMessaging msn = new Messenger(ServiceBusFixture.ConfigSettings.ServiceBusConnectionString, ServiceBusFixture.ConfigSettings.AzureSubscriptionId))
         {
             // We need to create the messenger before sending the messages to avoid writing non necessary code to create the queue
             // during the test. Receive will create the queue automatically. This breaks the AAA pattern by design.
@@ -98,7 +98,7 @@ public class MessengerQueueTest
                     if (rMessages.Count == messages.Count) ts.Cancel(); // kill switch
                 });
 
-            var sender = new MessageSender(ServiceBusFixture.ConfigSettings.ConnectionString, typeof(TestMessage).GetEntityName());
+            var sender = new MessageSender(ServiceBusFixture.ConfigSettings.ServiceBusConnectionString, typeof(TestMessage).GetEntityName());
             await sender.WriteBatchAsync(messages);
 
             try
@@ -116,7 +116,7 @@ public class MessengerQueueTest
     {
         await ServiceBusFixture.ServiceBusNamespace.ScorchNamespace();
 
-        using (IDoFullMessaging msn = new Messenger(ServiceBusFixture.ConfigSettings.ConnectionString, ServiceBusFixture.ConfigSettings.SubscriptionId))
+        using (IDoFullMessaging msn = new Messenger(ServiceBusFixture.ConfigSettings.ServiceBusConnectionString, ServiceBusFixture.ConfigSettings.AzureSubscriptionId))
         {
             await msn.Send(new TestMessage());
 
@@ -141,7 +141,7 @@ public class MessengerQueueTest
         await ServiceBusFixture.ServiceBusNamespace.ScorchNamespace();
 
         using (var ts = new CancellationTokenSource())
-        using (var msn = new Messenger(ServiceBusFixture.ConfigSettings.ConnectionString, ServiceBusFixture.ConfigSettings.SubscriptionId))
+        using (var msn = new Messenger(ServiceBusFixture.ConfigSettings.ServiceBusConnectionString, ServiceBusFixture.ConfigSettings.AzureSubscriptionId))
         {
             await msn.Send(new TestMessage());
 
@@ -173,7 +173,7 @@ public class MessengerQueueTest
         await ServiceBusFixture.ServiceBusNamespace.ScorchNamespace();
 
         using (var ts = new CancellationTokenSource())
-        using (var msn = new Messenger(ServiceBusFixture.ConfigSettings.ConnectionString, ServiceBusFixture.ConfigSettings.SubscriptionId))
+        using (var msn = new Messenger(ServiceBusFixture.ConfigSettings.ServiceBusConnectionString, ServiceBusFixture.ConfigSettings.AzureSubscriptionId))
         {
             await msn.Send(new TestMessage());
 
@@ -204,7 +204,7 @@ public class MessengerQueueTest
         await ServiceBusFixture.ServiceBusNamespace.ScorchNamespace();
 
         using (var ts = new CancellationTokenSource())
-        using (var msn = new Messenger(ServiceBusFixture.ConfigSettings.ConnectionString, ServiceBusFixture.ConfigSettings.SubscriptionId))
+        using (var msn = new Messenger(ServiceBusFixture.ConfigSettings.ServiceBusConnectionString, ServiceBusFixture.ConfigSettings.AzureSubscriptionId))
         {
             var message = new TestMessage();
             await msn.Send(message);
@@ -225,7 +225,7 @@ public class MessengerQueueTest
             }
             catch (TaskCanceledException) { /* soak the kill switch */ }
 
-            var receiver = new MessageReceiver(ServiceBusFixture.ConfigSettings.ConnectionString, EntityNameHelper.FormatDeadLetterPath(typeof(TestMessage).GetEntityName()), ReceiveMode.ReceiveAndDelete);
+            var receiver = new MessageReceiver(ServiceBusFixture.ConfigSettings.ServiceBusConnectionString, EntityNameHelper.FormatDeadLetterPath(typeof(TestMessage).GetEntityName()), ReceiveMode.ReceiveAndDelete);
             var rMessage = (await receiver.ReadBatchAsync<TestMessage>(1)).FirstOrDefault();
 
             rMessage.Should().NotBeNull();

--- a/src/Tests/Eshopworld.Messaging.Tests/MessengerTopicTest.cs
+++ b/src/Tests/Eshopworld.Messaging.Tests/MessengerTopicTest.cs
@@ -24,7 +24,7 @@ public class MessengerTopicTest
         ServiceBusFixture = serviceBusFixture;
     }
 
-    [Fact, IsIntegration]
+    [Fact, IsLayer1]
     public async Task Test_SendCreatesTheTopic()
     {
         await ServiceBusFixture.ServiceBusNamespace.ScorchNamespace();
@@ -36,7 +36,7 @@ public class MessengerTopicTest
         }
     }
 
-    [Fact, IsIntegration]
+    [Fact, IsLayer1]
     public async Task Test_ReceiveCreatesTheTopic()
     {
         await ServiceBusFixture.ServiceBusNamespace.ScorchNamespace();
@@ -49,7 +49,7 @@ public class MessengerTopicTest
         }
     }
 
-    [Fact, IsIntegration]
+    [Fact, IsLayer1]
     public async Task Test_SendingRandomEvents()
     {
         var sendCount = new Random().Next(1, 10);
@@ -81,7 +81,7 @@ public class MessengerTopicTest
         }
     }
 
-    [Fact, IsIntegration]
+    [Fact, IsLayer1]
     public async Task Test_ReceivingRandomEvents()
     {
         var receiveCount = new Random().Next(1, 10);

--- a/src/Tests/Eshopworld.Messaging.Tests/ServiceBusExtensionsTest.cs
+++ b/src/Tests/Eshopworld.Messaging.Tests/ServiceBusExtensionsTest.cs
@@ -8,7 +8,7 @@ public class ServiceBusExtensionsTest
 {
     public class GetNamespaceNameFromConnectionString
     {
-        [Fact, IsUnit]
+        [Fact, IsLayer0]
         public void Test_Parse_NormalConnectionString()
         {
             var namespaceName = "my-test-namespace";


### PR DESCRIPTION
Fixed a bug where when an app was running for a few hours and it attempted to managed entities within the Service Bus, it would fail with a fluent token expired exception.