### PR TITLE
Removing MS Test SDK

### DIFF
--- a/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
+++ b/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
@@ -28,7 +28,6 @@
     <PackageReference Include="jetbrains.annotations" Version="2019.1.1" />
     <PackageReference Include="microsoft.azure.management.fluent" Version="1.22.2" />
     <PackageReference Include="microsoft.azure.servicebus" Version="3.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="system.reactive" Version="4.1.5" />
   </ItemGroup>
 


### PR DESCRIPTION
Doesn't look like it's needed. 

Not going to bump the version for this one, be a waste of time bumping for an updated like this so I expect this change to be in the next release