### PR TITLE
fix rebuild sender receiver disposing instance used by other threads …

### DIFF
--- a/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
+++ b/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     
-    <Version>2.1.1-preview</Version>
+    <Version>2.1.1</Version>
     <PackageReleaseNotes>added synchronisation for connection resets to prevent exceptions</PackageReleaseNotes>
 
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
+++ b/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     
     <Version>2.1.1-preview</Version>
-    <PackageReleaseNotes>Added ability to override event names using EswEventName attribute</PackageReleaseNotes>
+    <PackageReleaseNotes>added synchronisation for connection resets to prevent exceptions</PackageReleaseNotes>
 
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
@@ -12,7 +12,7 @@
     
     <IsPackable>True</IsPackable>
     <PackageId>Eshopworld.Messaging</PackageId>
-    <Authors>David Rodrigues, David Guerin</Authors>
+    <Authors>David Rodrigues, David Guerin, Oisin Haken, Stephen Poland</Authors>
     <Company>eShopWorld</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/eShopWorld/messaging</PackageProjectUrl>

--- a/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
+++ b/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.31.0" />
     <PackageReference Include="microsoft.azure.servicebus" Version="4.1.1" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />
+    <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.0.0" />
     <PackageReference Include="polly" Version="7.2.0" />
     <PackageReference Include="system.reactive" Version="4.3.2" />
   </ItemGroup>

--- a/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
+++ b/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     
-    <Version>1.2.0</Version>
-    <PackageReleaseNotes>Nuget Updates</PackageReleaseNotes>
+    <Version>1.2.1</Version>
+    <PackageReleaseNotes>race conditions fixes</PackageReleaseNotes>
 
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.24.1" />
     <PackageReference Include="microsoft.azure.servicebus" Version="3.4.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.2.0" />
+    <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.0.0" />
     <PackageReference Include="polly" Version="7.1.0" />
     <PackageReference Include="system.reactive" Version="4.1.6" />
   </ItemGroup>

--- a/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
+++ b/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     
-    <Version>1.2.1</Version>
-    <PackageReleaseNotes>race conditions fixes</PackageReleaseNotes>
+    <Version>1.2.1-preview</Version>
+    <PackageReleaseNotes>race conditions fixes
+this is a preview version which has not yet been performance assesed</PackageReleaseNotes>
 
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>

--- a/src/Eshopworld.Messaging/Messenger.cs
+++ b/src/Eshopworld.Messaging/Messenger.cs
@@ -215,6 +215,7 @@ namespace Eshopworld.Messaging
                 if (!ServiceBusAdapters.TryAdd(typeof(T), adapter))
                 {
                     adapter.Dispose();
+                    adapter = null;
                 }
             }
 

--- a/src/Eshopworld.Messaging/QueueAdapter.cs
+++ b/src/Eshopworld.Messaging/QueueAdapter.cs
@@ -23,7 +23,7 @@ namespace Eshopworld.Messaging
         internal readonly IQueue AzureQueue;
 
         internal MessageSender Sender;
-        internal AsyncReaderWriterLock SenderLock = new AsyncReaderWriterLock();
+        internal readonly AsyncReaderWriterLock SenderLock = new AsyncReaderWriterLock();
 
         /// <summary>
         /// Initializes a new instance of <see cref="QueueAdapter{T}"/>.

--- a/src/Eshopworld.Messaging/QueueAdapter.cs
+++ b/src/Eshopworld.Messaging/QueueAdapter.cs
@@ -7,6 +7,7 @@ using Microsoft.Azure.Management.ServiceBus.Fluent;
 using Microsoft.Azure.ServiceBus;
 using Microsoft.Azure.ServiceBus.Core;
 using Newtonsoft.Json;
+using Nito.AsyncEx;
 
 namespace Eshopworld.Messaging
 {
@@ -22,6 +23,7 @@ namespace Eshopworld.Messaging
         internal readonly IQueue AzureQueue;
 
         internal MessageSender Sender;
+        internal AsyncReaderWriterLock SenderLock = new AsyncReaderWriterLock();
 
         /// <summary>
         /// Initializes a new instance of <see cref="QueueAdapter{T}"/>.
@@ -77,7 +79,10 @@ namespace Eshopworld.Messaging
                 {
                     try
                     {
-                        await Sender.SendAsync(qMessage).ConfigureAwait(false);
+                        using (await SenderLock.ReaderLockAsync())
+                        {
+                            await Sender.SendAsync(qMessage).ConfigureAwait(false);
+                        }
                     }
                     catch
                     {
@@ -104,23 +109,29 @@ namespace Eshopworld.Messaging
         /// <inheritdoc />
         protected override async Task RebuildReceiver()
         {
-            if (Receiver != null && !Receiver.IsClosedOrClosing)
+            using (await ReceiverLock.WriterLockAsync())
             {
-                await Receiver.CloseAsync().ConfigureAwait(false);
-            }
+                if (Receiver != null && !Receiver.IsClosedOrClosing)
+                {
+                    await Receiver.CloseAsync().ConfigureAwait(false);
+                }
 
-            Receiver = new MessageReceiver(ConnectionString, AzureQueue.Name, ReceiveMode.PeekLock, new RetryExponential(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(500), 3), BatchSize);
+                Receiver = new MessageReceiver(ConnectionString, AzureQueue.Name, ReceiveMode.PeekLock, new RetryExponential(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(500), 3), BatchSize);
+            }
         }
 
         /// <inheritdoc />
         protected override async Task RebuildSender()
         {
-            if (Sender != null && !Sender.IsClosedOrClosing)
+            using (await SenderLock.WriterLockAsync())
             {
-                await Sender.CloseAsync().ConfigureAwait(false);
-            }
+                if (Sender != null && !Sender.IsClosedOrClosing)
+                {
+                    await Sender.CloseAsync().ConfigureAwait(false);
+                }
 
-            Sender = new MessageSender(ConnectionString, AzureQueue.Name, new RetryExponential(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(500), 3));
+                Sender = new MessageSender(ConnectionString, AzureQueue.Name, new RetryExponential(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(500), 3));
+            }
         }
     }
 }

--- a/src/Eshopworld.Messaging/TopicAdapter.cs
+++ b/src/Eshopworld.Messaging/TopicAdapter.cs
@@ -104,6 +104,15 @@ I suggest you reduce the size of the namespace: '{TopicType.Namespace}'.");
                             await Sender.SendAsync(qMessage).ConfigureAwait(false);
                         }
                     }
+                    /**
+                     * we want to minimize the client rebuild frequency and ideally the reverse the approach
+                     * rebuild only when there is valid reason to do so
+                     * this list will need to be compiled/maintained
+                     */
+                    catch (QuotaExceededException) //let the polly deal with this - retry if allowed
+                    {
+                        throw;
+                    }
                     catch
                     {
                         await RebuildSender().ConfigureAwait(false);

--- a/src/Eshopworld.Messaging/TopicAdapter.cs
+++ b/src/Eshopworld.Messaging/TopicAdapter.cs
@@ -7,6 +7,7 @@ using Microsoft.Azure.Management.ServiceBus.Fluent;
 using Microsoft.Azure.ServiceBus;
 using Microsoft.Azure.ServiceBus.Core;
 using Newtonsoft.Json;
+using Nito.AsyncEx;
 
 namespace Eshopworld.Messaging
 {
@@ -24,6 +25,7 @@ namespace Eshopworld.Messaging
         internal TopicClient Sender;
         internal ISubscription AzureTopicSubscription;
         internal string SubscriptionName;
+        internal AsyncReaderWriterLock senderLock = new AsyncReaderWriterLock();
 
         /// <summary>
         /// Initializes a new instance of <see cref="TopicAdapter{T}"/>.
@@ -50,7 +52,7 @@ I suggest you reduce the size of the namespace: '{TopicType.Namespace}'.");
 
             AzureTopic = Messenger.GetRefreshedServiceBusNamespace().ConfigureAwait(false).GetAwaiter().GetResult()
                                   .CreateTopicIfNotExists(TopicType.GetEntityName()).ConfigureAwait(false).GetAwaiter().GetResult();
-
+      
             RebuildSender().ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
@@ -97,7 +99,10 @@ I suggest you reduce the size of the namespace: '{TopicType.Namespace}'.");
                 {
                     try
                     {
-                        await Sender.SendAsync(qMessage).ConfigureAwait(false);
+                        using (await senderLock.ReaderLockAsync())
+                        {
+                            await Sender.SendAsync(qMessage).ConfigureAwait(false);
+                        }
                     }
                     catch
                     {
@@ -131,23 +136,29 @@ I suggest you reduce the size of the namespace: '{TopicType.Namespace}'.");
         /// <inheritdoc />
         protected override async Task RebuildReceiver()
         {
-            if (Receiver != null && !Receiver.IsClosedOrClosing)
+            using (await ReceiverLock.WriterLockAsync())
             {
-                await Receiver.CloseAsync().ConfigureAwait(false);
-            }
+                if (Receiver != null && !Receiver.IsClosedOrClosing)
+                {
+                    await Receiver.CloseAsync().ConfigureAwait(false);
+                }
 
-            Receiver = new MessageReceiver(ConnectionString, EntityNameHelper.FormatSubscriptionPath(AzureTopic.Name, SubscriptionName), ReceiveMode.PeekLock, new RetryExponential(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(500), 3), BatchSize);
+                Receiver = new MessageReceiver(ConnectionString, EntityNameHelper.FormatSubscriptionPath(AzureTopic.Name, SubscriptionName), ReceiveMode.PeekLock, new RetryExponential(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(500), 3), BatchSize);
+            }
         }
 
         /// <inheritdoc />
         protected override async Task RebuildSender()
         {
-            if (Sender != null && !Sender.IsClosedOrClosing)
+            using (await senderLock.WriterLockAsync())
             {
-                await Sender.CloseAsync().ConfigureAwait(false);
-            }
+                if (Sender != null && !Sender.IsClosedOrClosing)
+                {
+                    await Sender.CloseAsync().ConfigureAwait(false);
+                }
 
-            Sender = new TopicClient(ConnectionString, AzureTopic.Name, new RetryExponential(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(500), 3));
+                Sender = new TopicClient(ConnectionString, AzureTopic.Name, new RetryExponential(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(500), 3));
+            }
         }
 
         /// <inheritdoc />

--- a/src/Eshopworld.Messaging/TopicAdapter.cs
+++ b/src/Eshopworld.Messaging/TopicAdapter.cs
@@ -25,7 +25,7 @@ namespace Eshopworld.Messaging
         internal TopicClient Sender;
         internal ISubscription AzureTopicSubscription;
         internal string SubscriptionName;
-        internal AsyncReaderWriterLock senderLock = new AsyncReaderWriterLock();
+        internal readonly AsyncReaderWriterLock SenderLock = new AsyncReaderWriterLock();
 
         /// <summary>
         /// Initializes a new instance of <see cref="TopicAdapter{T}"/>.
@@ -99,13 +99,13 @@ I suggest you reduce the size of the namespace: '{TopicType.Namespace}'.");
                 {
                     try
                     {
-                        using (await senderLock.ReaderLockAsync())
+                        using (await SenderLock.ReaderLockAsync())
                         {
                             await Sender.SendAsync(qMessage).ConfigureAwait(false);
                         }
                     }
                     /**
-                     * we want to minimize the client rebuild frequency and ideally the reverse the approach
+                     * we want to minimize the client rebuild frequency and ideally to reverse the approach
                      * rebuild only when there is valid reason to do so
                      * this list will need to be compiled/maintained
                      */
@@ -159,7 +159,7 @@ I suggest you reduce the size of the namespace: '{TopicType.Namespace}'.");
         /// <inheritdoc />
         protected override async Task RebuildSender()
         {
-            using (await senderLock.WriterLockAsync())
+            using (await SenderLock.WriterLockAsync())
             {
                 if (Sender != null && !Sender.IsClosedOrClosing)
                 {

--- a/src/Tests/Eshopworld.Messaging.Tests/AzureServiceBusFixture.cs
+++ b/src/Tests/Eshopworld.Messaging.Tests/AzureServiceBusFixture.cs
@@ -82,6 +82,8 @@ namespace Eshopworld.Messaging.Tests
     {
         public string ServiceBusConnectionString { get; set; }
 
+        public string ListenOnlyServiceBusConnectionString { get; set; }
+
         public string AzureSubscriptionId { get; set; }
     }
 }

--- a/src/Tests/Eshopworld.Messaging.Tests/MessengerTopicTest.cs
+++ b/src/Tests/Eshopworld.Messaging.Tests/MessengerTopicTest.cs
@@ -60,7 +60,6 @@ public class MessengerTopicTest
             {
                 global = Task.WhenAll(tasks);
                 await global;
-                Assert.True(!global.IsFaulted);
             }
             catch (Exception)
             {

--- a/src/Tests/Eshopworld.Messaging.Tests/MessengerTopicTest.cs
+++ b/src/Tests/Eshopworld.Messaging.Tests/MessengerTopicTest.cs
@@ -37,6 +37,41 @@ public class MessengerTopicTest
     }
 
     [Fact, IsLayer1]
+    public async Task Test_SendFailureCorrectRebuildSequence()
+    {
+        await ServiceBusFixture.ServiceBusNamespace.ScorchNamespace();
+
+        using (IDoFullMessaging msn = new Messenger(ServiceBusFixture.ConfigSettings.ServiceBusConnectionString, ServiceBusFixture.ConfigSettings.AzureSubscriptionId))
+        {
+            await msn.Publish(new TestMessage());
+            ServiceBusFixture.ServiceBusNamespace.AssertSingleTopicExists(typeof(TestMessage));
+        }
+
+        using (IDoFullMessaging msn = new Messenger(ServiceBusFixture.ConfigSettings.ListenOnlyServiceBusConnectionString, ServiceBusFixture.ConfigSettings.AzureSubscriptionId))
+        {
+            var tasks = new List<Task>();
+            for (int x=0; x<100; x++)
+            {
+                tasks.Add(Task.Run(()=> msn.Publish(new TestMessage())));
+            }
+
+            Task global=null; 
+            try
+            {
+                global = Task.WhenAll(tasks);
+                await global;
+                Assert.True(!global.IsFaulted);
+            }
+            catch (Exception)
+            {
+                Assert.All(global.Exception.InnerExceptions, (t) => Assert.True(t is UnauthorizedException));
+            }
+
+        }
+
+    }
+
+    [Fact, IsLayer1]
     public async Task Test_ReceiveCreatesTheTopic()
     {
         await ServiceBusFixture.ServiceBusNamespace.ScorchNamespace();


### PR DESCRIPTION
…concurrently


so ultimately I saw over 10K of ObjectDisposedExceptions during Captain Hook perf test thrown by Peter pan using Publish

the flow was as follow
 - Azure started issuing service quota exceeded, which the code tried to rectify by rebuilding the sender, but other threads already entered send flow and the client checks internally for inner objects (connection etc.) being disposed, which prompted all those exceptions - **the key here** was **high failure rate** (at that time 100%) resulting in **high rebuild rate**

I am aware of the fact that the retry was done primarily for auth stuff but since I cannot (and I doubt anybody) can compile complete list of exceptions to cover by rebuilding the client I merely attempted to fix in general

the async reader writer lock gives multi reader/single write exclusivity in async mode and so rebuild can be done in isolation

I also saw the race condition when adapters are created when the code was checking for tryadd returning false (as it means adapter for the type was already added by competing thread) by disposing it but then returning it

any questions, shout


**I added** a test for this - since I would not be able to reliably repro a service quota I trigger the exception by supplying connection string w/o send claim , this throws the exception upon send and reproduces the problem when under load