### PR TITLE
Update TypeExtensions to test for an EswEventName attribute

### DIFF
--- a/src/Eshopworld.Messaging/ServiceBusExtensions.cs
+++ b/src/Eshopworld.Messaging/ServiceBusExtensions.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Eshopworld.Core;
 using Microsoft.Azure.Management.ServiceBus.Fluent;
 
 namespace Eshopworld.Messaging
@@ -104,7 +106,8 @@ namespace Eshopworld.Messaging
         public static string GetEntityName(this Type type)
         {
 #if DEBUG
-            var queueName = type.FullName;
+            var queueName = GetQueueNameForType(type);
+
             if (Debugger.IsAttached)
             {
                 queueName += $"-{Environment.UserName.Replace("$", "")}";
@@ -112,8 +115,14 @@ namespace Eshopworld.Messaging
 
             return queueName?.ToLower();
 #else
-            return type.FullName?.ToLower();
+            return GetQueueNameForType(type)?.ToLower();
 #endif
+        }
+
+        private static string GetQueueNameForType(Type type)
+        {
+            var attributeEventName = type.GetCustomAttribute<EswEventNameAttribute>()?.EventName;
+            return string.IsNullOrWhiteSpace(attributeEventName) ? type.FullName : attributeEventName;
         }
     }
 }

--- a/src/Tests/Eshopworld.Messaging.Tests/TypeExtensionsTests.cs
+++ b/src/Tests/Eshopworld.Messaging.Tests/TypeExtensionsTests.cs
@@ -1,0 +1,73 @@
+﻿using Eshopworld.Core;
+using Eshopworld.Tests.Core;
+using FluentAssertions;
+using Xunit;
+
+namespace Eshopworld.Messaging.Tests
+{
+    public class TypeExtensionsTests
+    {
+        [Fact, IsLayer0]
+        public void GetEntityName_TypeWithoutEswEventNameAttribute_ShouldReturnTypeFullName()
+        {
+            // Arrange
+            var type = typeof(TypeWithoutAttribute);
+
+            // Act
+            var entityName = type.GetEntityName();
+
+            // Assert
+            entityName.Should().Be(type.FullName?.ToLower());
+        }
+
+        [Fact, IsLayer0]
+        public void GetEntityName_TypeWithEswEventNameAttribute_ShouldReturnNameProvidedByAttribute()
+        {
+            // Arrange
+            var type = typeof(TypeWithAttribute);
+
+            // Act
+            var entityName = type.GetEntityName();
+
+            // Assert
+            entityName.Should().Be("test.event.name");
+        }
+
+        [Fact, IsLayer0]
+        public void GetEntityName_TypeWithEmptyEswEventNameAttributeValue_ShouldReturnTypeFullName()
+        {
+            // Arrange
+            var type = typeof(TypeWithEmptyAttributeValue);
+
+            // Act
+            var entityName = type.GetEntityName();
+
+            // Assert
+            entityName.Should().Be(type.FullName?.ToLower());
+        }
+
+        [Fact, IsLayer0]
+        public void GetEntityName_TypeWithWhiteSpaceEswEventNameAttributeValue_ShouldReturnTypeFullName()
+        {
+            // Arrange
+            var type = typeof(TypeWithWhiteSpaceAttributeValue);
+
+            // Act
+            var entityName = type.GetEntityName();
+
+            // Assert
+            entityName.Should().Be(type.FullName?.ToLower());
+        }
+
+        private class TypeWithoutAttribute { }
+
+        [EswEventName("Test.Event.Name")]
+        private class TypeWithAttribute { }
+
+        [EswEventName("")]
+        private class TypeWithEmptyAttributeValue { }
+
+        [EswEventName("   ")]
+        private class TypeWithWhiteSpaceAttributeValue { }
+    }
+}


### PR DESCRIPTION
Currently the name of the type is used as the event name and it causes problems for code management. As such we need a means to override the name of this event.

This PR updates the GetEntityName method in the TypeExtensions class to include a test for a queue name passed in via an EswEventNameAttribute before returning the types full name. If it exists, it should take precedence and be used ahead of the type name.